### PR TITLE
Clarify immutability

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -5,7 +5,7 @@
 <script src="./spec.js"></script>
 <pre class="metadata">
 title: Proposal Import Bytes
-stage: 0
+stage: 2
 contributors: Steven, Guy Bedford
 </pre>
 <emu-intro id="intro">

--- a/spec.emu
+++ b/spec.emu
@@ -75,7 +75,7 @@ contributors: Steven, Guy Bedford
     </emu-note>
 
     <emu-note>
-      <p>All of the import statements in the module graph that address the same JSON <ins>or bytes </ins>module may evaluate to the same mutable object.</p>
+      <p>All of the import statements in the module graph that address the same JSON <ins>or bytes </ins>module may evaluate to the same <del>mutable </del>object.</p>
     </emu-note>
   </emu-clause>
 
@@ -114,7 +114,7 @@ contributors: Steven, Guy Bedford
       <h1>
         <ins>
           CreateBytesModule (
-            _arrayBuffer_: an immutable ArrayBuffer or a SharedArrayBuffer
+            _arrayBuffer_: an immutable ArrayBuffer or an immutable SharedArrayBuffer
           ): a Synthetic Module Record
         </ins>
       </h1>


### PR DESCRIPTION
It took me a few iterations of reading the spec to figure out that bytes are indeed immutable, and not mutable, as implied by the last note of HostLoadImportedModule. Similarly, in CreateBytesModule it's not immediately obvious that the "immutable" descriptor applies to SharedArrayBuffer as well.

As an unrelated bit of cleanup, the spec metadata is updated to match the current stage of the proposal.